### PR TITLE
シフト表示用のテーブルをcomponentとして切り分ける

### DIFF
--- a/app/controllers/api/v1/staff/fixed_shifts_controller.rb
+++ b/app/controllers/api/v1/staff/fixed_shifts_controller.rb
@@ -1,10 +1,22 @@
 class Api::V1::Staff::FixedShiftsController < ApplicationController
+  before_action :get_date_for_twomonths
+
   def index
-    @shifts = FixedShift.all
+    # 所属店舗のシフトデータを検索し、現在から１ヶ月先の期間で絞り込んで取得
+    @shifts = FixedShift.where(shop_id: current_user.shop_id, clock_in: @from...@to)
   end
 
   def current_user_fixed_shifts
-    shifts = current_user.fixed_shifts
+    binding.pry
+    @shifts = current_user.fixed_shifts.where(clock_in: @from...@to)
     render :shifts
   end
+
+  private
+    def get_date_for_twomonths
+      #取得するシフトの絞り込みのため、デフォルトの設定期間として２ヶ月間を定義
+      today = Time.current.at_beginning_of_day
+      @from = (today - 1 .month)
+      @to = (@from + 1.month)
+    end
 end

--- a/app/controllers/api/v1/staff/fixed_shifts_controller.rb
+++ b/app/controllers/api/v1/staff/fixed_shifts_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::Staff::FixedShiftsController < ApplicationController
   def index
-    shifts = FixedShift.all
-    render json: shifts
+    @shifts = FixedShift.all
+  end
+
+  def current_user_fixed_shifts
+    shifts = current_user.fixed_shifts
+    render :shifts
   end
 end

--- a/app/controllers/api/v1/staff/fixed_shifts_controller.rb
+++ b/app/controllers/api/v1/staff/fixed_shifts_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::Staff::FixedShiftsController < ApplicationController
-  before_action :get_date_for_twomonths
+  before_action :get_month
 
   def index
     # 所属店舗のシフトデータを検索し、現在から１ヶ月先の期間で絞り込んで取得
-    @shifts = FixedShift.where(shop_id: current_user.shop_id, clock_in: @from...@to)
+    @shifts = FixedShift.where(shop_id: current_user.shop_id, clock_in: @month.all_month)
   end
 
   def current_user_fixed_shifts
@@ -12,10 +12,8 @@ class Api::V1::Staff::FixedShiftsController < ApplicationController
   end
 
   private
-    def get_date_for_twomonths
+    def get_month
       #取得するシフトの絞り込みのため、デフォルトの設定期間として日付範囲を定義(現在の日にちを基準に前後１ヶ月)
-      today = Time.current.at_beginning_of_day
-      @from = (today - 1 .month)
-      @to = (today + 1.month)
+      @month = params[:month] ? Date.parse(params[:month]) : Time.zone.today
     end
 end

--- a/app/controllers/api/v1/staff/fixed_shifts_controller.rb
+++ b/app/controllers/api/v1/staff/fixed_shifts_controller.rb
@@ -4,19 +4,19 @@ class Api::V1::Staff::FixedShiftsController < ApplicationController
   def index
     # 所属店舗のシフトデータを検索し、現在から１ヶ月先の期間で絞り込んで取得
     @shifts = FixedShift.where(shop_id: current_user.shop_id, clock_in: @from...@to)
+    binding.pry
   end
 
   def current_user_fixed_shifts
-    binding.pry
     @shifts = current_user.fixed_shifts.where(clock_in: @from...@to)
     render :shifts
   end
 
   private
     def get_date_for_twomonths
-      #取得するシフトの絞り込みのため、デフォルトの設定期間として２ヶ月間を定義
+      #取得するシフトの絞り込みのため、デフォルトの設定期間として日付範囲を定義(現在の日にちを基準に前後１ヶ月)
       today = Time.current.at_beginning_of_day
       @from = (today - 1 .month)
-      @to = (@from + 1.month)
+      @to = (today + 1.month)
     end
 end

--- a/app/controllers/api/v1/staff/fixed_shifts_controller.rb
+++ b/app/controllers/api/v1/staff/fixed_shifts_controller.rb
@@ -4,7 +4,6 @@ class Api::V1::Staff::FixedShiftsController < ApplicationController
   def index
     # 所属店舗のシフトデータを検索し、現在から１ヶ月先の期間で絞り込んで取得
     @shifts = FixedShift.where(shop_id: current_user.shop_id, clock_in: @from...@to)
-    binding.pry
   end
 
   def current_user_fixed_shifts

--- a/app/javascript/components/FixedShiftsCalendar.vue
+++ b/app/javascript/components/FixedShiftsCalendar.vue
@@ -89,6 +89,7 @@ export default {
         this.month--
       }
         this.day = -1
+        this.$emit('changeMonth', `${this.year}/${this.month}`);
     },
 
     // 翌月のカレンダーを取得
@@ -100,6 +101,7 @@ export default {
         this.month++
       }
         this.day = -1
+        this.$emit('changeMonth', `${this.year}/${this.month}`);
     },
     
     setShifts(date) {

--- a/app/javascript/components/Modal.vue
+++ b/app/javascript/components/Modal.vue
@@ -54,14 +54,14 @@ export default {
       ],
 
       setData: {
-        year: null,
-        month: null,
-        date: null,
-        clockIn: null,
-        clockOut: null,
-        shiftId: null,
-        userId: null,
-        index: null
+        year: 0,
+        month: 0,
+        date: 0,
+        clockIn: "",
+        clockOut: "",
+        shiftId: 0,
+        userId: 0,
+        index: 0
       }
     }
   },

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -4,7 +4,7 @@
   <div>
     <div v-if="filteredShifts.length">
       
-      <table v-if="admin">
+      <table>
         <tbody>
           <tr>
             <th>氏名</th>
@@ -15,31 +15,13 @@
           </tr>
           <tr v-for="(shift) in filteredShifts" :key="shift.id" >
             <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
-            <td><userAge :key="item.id" :userAge="item.user.age" ></userAge></td>
+            <td v-if="admin"><userAge :key="item.id" :userAge="item.user.age" ></userAge></td>
             <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
             <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
             <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
           </tr>
         </tbody>
       </table>
-
-      <table v-else>
-        <tbody>
-          <tr>
-            <th>氏名</th>
-            <th>勤務ステータス</th>
-            <th>希望出勤時間</th>
-            <th>希望退勤時間</th>
-          </tr>
-          <tr v-for="(shift) in filteredShifts" :key="shift.id" >
-            <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
-            <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
-            <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
-            <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
-          </tr>
-        </tbody>
-      </table>
-
     </div>
     <div v-else>
       <p>出勤予定の方がいません</p>

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -1,30 +1,49 @@
 <!-- シフトを一覧表示するテーブル -->
 
 <template>
-<div>
+  <div>
+    <div v-if="filteredShiftData.length">
+      
+      <table v-if="this.admin===true">
+        <tbody>
+          <tr>
+            <th>氏名</th>
+            <th>年齢</th>
+            <th>勤務ステータス</th>
+            <th>希望出勤時間</th>
+            <th>希望退勤時間</th>
+          </tr>
+          <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
+            <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
+            <td><userAge :key="item.id" :userAge="item.user.age" ></userAge></td>
+            <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
+            <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
+            <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
+          </tr>
+        </tbody>
+      </table>
 
-  <div v-if="filteredShiftData.length">
-    <table>
-      <tbody>
-        <tr>
-          <th>氏名</th>
-          <th>年齢</th>
-          <th>勤務ステータス</th>
-          <th>希望出勤時間</th>
-          <th>希望退勤時間</th>
-        </tr>
-        <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
-          <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
-          <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
-          <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
-          <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div v-else>
-    <p>出勤予定の方がいません</p>
-  </div>
+      <table v-else>
+        <tbody>
+          <tr>
+            <th>氏名</th>
+            <th>勤務ステータス</th>
+            <th>希望出勤時間</th>
+            <th>希望退勤時間</th>
+          </tr>
+          <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
+            <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
+            <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
+            <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
+            <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+    <div v-else>
+      <p>出勤予定の方がいません</p>
+    </div>
 </div>
 </template>
 
@@ -49,7 +68,8 @@ export default({
     'fixedShifts',
     'year',
     'month',
-    'date'
+    'date',
+    'admin'
   ],
 
   computed: {

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -4,7 +4,7 @@
   <div>
     <div v-if="filteredShifts.length">
       
-      <table v-if="this.admin===true">
+      <table v-if="admin">
         <tbody>
           <tr>
             <th>氏名</th>

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -1,0 +1,63 @@
+<!-- シフトを一覧表示するテーブル -->
+
+<template>
+<div>
+
+  <div v-if="filteredShiftData.length">
+    <table>
+      <tbody>
+        <tr>
+          <th>氏名</th>
+          <th>年齢</th>
+          <th>勤務ステータス</th>
+          <th>希望出勤時間</th>
+          <th>希望退勤時間</th>
+        </tr>
+        <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
+          <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
+          <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
+          <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
+          <td><requestedClockOutTime :key="shift.id" :clockOut="shift.clock_out" ></requestedClockOutTime></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div v-else>
+    <p>出勤予定の方がいません</p>
+  </div>
+</div>
+</template>
+
+<script>
+  import dayjs from "dayjs"
+  import UserName from "./UserName.vue"
+  import UserAge from "./UserAge.vue"
+  import UserWorkStatus from "./UserWorkStatus.vue"
+  import RequestedClockInTime from "./RequestedClockInTime.vue"
+  import RequestedClockOutTime from "./RequestedClockOutTime.vue"
+
+export default({
+  components: {
+    UserName,
+    UserAge,
+    UserWorkStatus,
+    RequestedClockInTime,
+    RequestedClockOutTime,
+  },
+
+  props: [
+    'fixedShifts',
+    'year',
+    'month',
+    'date'
+  ],
+
+  computed: {
+      // カレンダーで指定した日付のシフト情報とそのシフトのユーザー情報を取得し表示する
+      filteredShiftData() {
+        const calendarDate = dayjs(this.year + "-" + this.month + "-" + this.date).format("DD/MM/YYYY")
+        return this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
+      },
+    },
+})
+</script>

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -48,7 +48,6 @@
 </template>
 
 <script>
-  import dayjs from "dayjs"
   import UserName from "./UserName.vue"
   import UserAge from "./UserAge.vue"
   import UserWorkStatus from "./UserWorkStatus.vue"

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div>
-    <div v-if="filteredShifts.length">
+    <div v-if="shifts.length">
       
       <table>
         <tbody>
@@ -13,7 +13,7 @@
             <th>希望出勤時間</th>
             <th>希望退勤時間</th>
           </tr>
-          <tr v-for="(shift) in filteredShifts" :key="shift.id" >
+          <tr v-for="(shift) in shifts" :key="shift.id" >
             <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
             <td v-if="admin"><userAge :key="item.id" :userAge="item.user.age" ></userAge></td>
             <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
@@ -46,7 +46,7 @@ export default({
   },
 
   props: [
-    'filteredShifts',
+    'shifts',
     'admin'
   ]
 })

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div>
-    <div v-if="filteredShiftData.length">
+    <div v-if="filteredShifts.length">
       
       <table v-if="this.admin===true">
         <tbody>
@@ -13,7 +13,7 @@
             <th>希望出勤時間</th>
             <th>希望退勤時間</th>
           </tr>
-          <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
+          <tr v-for="(shift) in filteredShifts" :key="shift.id" >
             <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
             <td><userAge :key="item.id" :userAge="item.user.age" ></userAge></td>
             <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
@@ -31,7 +31,7 @@
             <th>希望出勤時間</th>
             <th>希望退勤時間</th>
           </tr>
-          <tr v-for="(shift) in filteredShiftData" :key="shift.id" >
+          <tr v-for="(shift) in filteredShifts" :key="shift.id" >
             <td><userName :key="shift.id" :userName="shift.user.name" ></userName></td>
             <td><userWorkStatus :key="shift.id" :userData="shift.user" ></userWorkStatus></td>
             <td><requestedClockInTime :key="shift.id" :clockIn="shift.clock_in" ></requestedClockInTime></td>
@@ -65,19 +65,8 @@ export default({
   },
 
   props: [
-    'fixedShifts',
-    'year',
-    'month',
-    'date',
+    'filteredShifts',
     'admin'
-  ],
-
-  computed: {
-      // カレンダーで指定した日付のシフト情報とそのシフトのユーザー情報を取得し表示する
-      filteredShiftData() {
-        const calendarDate = dayjs(this.year + "-" + this.month + "-" + this.date).format("DD/MM/YYYY")
-        return this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
-      },
-    },
+  ]
 })
 </script>

--- a/app/javascript/components/ShiftTable.vue
+++ b/app/javascript/components/ShiftTable.vue
@@ -8,7 +8,7 @@
         <tbody>
           <tr>
             <th>氏名</th>
-            <th>年齢</th>
+            <th v-if="admin">年齢</th>
             <th>勤務ステータス</th>
             <th>希望出勤時間</th>
             <th>希望退勤時間</th>

--- a/app/javascript/views/admin/FixedShiftsIndex.vue
+++ b/app/javascript/views/admin/FixedShiftsIndex.vue
@@ -78,11 +78,11 @@
     data() {
       return{
         selectedShift: {},
-        year: null,
-        month: null,
-        date: null,
-        showModal: false,
-        index: null
+        year: 0,
+        month: 0,
+        date: 0,
+        index: 0,
+        showModal: false
       }
     },
 

--- a/app/javascript/views/admin/RequestedShiftsIndex.vue
+++ b/app/javascript/views/admin/RequestedShiftsIndex.vue
@@ -79,11 +79,11 @@
     data() {
       return{
         selectedShift: {},
-        year: null,
-        month: null,
-        date: null,
-        showModal: false,
-        index: null
+        year: 0,
+        month: 0,
+        date: 0,
+        index: 0,
+        showModal: false
       }
     },
 

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -6,50 +6,26 @@
     <div v-if="this.month && this.date">
       <h2>{{ this.month }}月{{ this.date }}日の出勤予定者</h2>
     </div>
-    <div v-if="filteredShiftData.length">
-      <table>
-        <tbody>
-          <tr>
-            <th>氏名</th>
-            <th>年齢</th>
-            <th>勤務ステータス</th>
-            <th>希望出勤時間</th>
-            <th>希望退勤時間</th>
-          </tr>
-          <tr v-for="(item) in filteredShiftData" :key="item.id" >
-            <td><userName :key="item.id" :userName="item.user.name" ></userName></td>
-            <td><userWorkStatus :key="item.id" :userData="item.user" ></userWorkStatus></td>
-            <td><requestedClockInTime :key="item.id" :clockIn="item.clock_in" ></requestedClockInTime></td>
-            <td><requestedClockOutTime :key="item.id" :clockOut="item.clock_out" ></requestedClockOutTime></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    
-    <div v-else>
-      <p>出勤予定の方がいません</p>
-    </div>
+
+    <shift-table
+      :fixedShifts="fixedShifts"
+      :year="year"
+      :month="month"
+      :date="date"
+    ></shift-table>
   </div>
 </template>
 
 <script>
   import dayjs from "dayjs";
   import Calendar from "../../components/FixedShiftsCalendar.vue"
-  import UserName from "../../components/UserName.vue"
-  import UserAge from "../../components/UserAge.vue"
-  import UserWorkStatus from "../../components/UserWorkStatus.vue"
-  import RequestedClockInTime from "../../components/RequestedClockInTime.vue"
-  import RequestedClockOutTime from "../../components/RequestedClockOutTime.vue"
   import axios from "axios";
+  import ShiftTable from '../../components/ShiftTable.vue';
 
   export default {
     components: {
       Calendar,
-      UserName,
-      UserAge,
-      UserWorkStatus,
-      RequestedClockInTime,
-      RequestedClockOutTime
+      ShiftTable
     },
 
     data() {
@@ -67,18 +43,12 @@
       this.fetchFixedShifts();
       this.$store.dispatch("getAllUsers")
     },
-    computed: {
-      // カレンダーで指定した日付のシフト情報とそのシフトのユーザー情報を取得し表示する
-      filteredShiftData() {
-        const calendarDate = dayjs(this.year + "-" + this.month + "-" + this.date).format("DD/MM/YYYY")
-        return this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
-      },
-    },
 
     methods: {
       async fetchFixedShifts() {
         const response = await axios.get("/api/v1/staff/fixed_shifts")
         this.fixedShifts = response.data
+        console.log(this.fixedShifts)
       },
       // クリックカレンダーの日付情報をdataに格納しcomputed: filteredShiftでの処理に使用する
       checkShifts(value) {

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -8,7 +8,7 @@
     </div>
 
     <shift-table
-      :filteredShifts="filteredShifts"
+      :shifts="filteredShifts"
       :admin="false"
     ></shift-table>
   </div>
@@ -48,9 +48,10 @@
           })
         this.fixedShifts = response.data
       },
+
       // クリックカレンダーの日付情報をdataに格納しcomputed: filteredShiftでの処理に使用する
-      checkShifts(checkDate) {
-        const calendarDate = dayjs(checkDate.year + "-" + checkDate.month + "-" + checkDate.date).format("DD/MM/YYYY")
+      filterShifts(date) {
+        const calendarDate = dayjs(date.year + "-" + date.month + "-" + date.date).format("DD/MM/YYYY")
         this.filteredShifts =  this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
       }
     },

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -12,6 +12,7 @@
       :year="year"
       :month="month"
       :date="date"
+      :admin="false"
     ></shift-table>
   </div>
 </template>

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -2,7 +2,7 @@
 
 <template>
   <div>
-    <calendar @sendDate="checkShifts"/>
+    <calendar @sendDate="filterShifts" @changeMonth="fetchFixedShifts"/>
     <div v-if="this.month && this.date">
       <h2>{{ this.month }}月{{ this.date }}日の出勤予定者</h2>
     </div>
@@ -40,10 +40,13 @@
     },
 
     methods: {
-      async fetchFixedShifts() {
-        const response = await axios.get("/api/v1/staff/fixed_shifts")
+      async fetchFixedShifts(month) {
+        // カレンダーcomponentで月の変更があったときはparamとして月データを送る
+        const response = await axios.get(
+          "/api/v1/staff/fixed_shifts",{
+            params: { month: month }
+          })
         this.fixedShifts = response.data
-        console.log(this.fixedShifts)
       },
       // クリックカレンダーの日付情報をdataに格納しcomputed: filteredShiftでの処理に使用する
       checkShifts(checkDate) {

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -8,10 +8,7 @@
     </div>
 
     <shift-table
-      :fixedShifts="fixedShifts"
-      :year="year"
-      :month="month"
-      :date="date"
+      :filteredShifts="filteredShifts"
       :admin="false"
     ></shift-table>
   </div>
@@ -37,12 +34,12 @@
         year: null,
         month: null,
         date: null,
-        fixedShifts: []
+        fixedShifts: [],
+        filteredShifts: []
       }
     },
     created() {
       this.fetchFixedShifts();
-      this.$store.dispatch("getAllUsers")
     },
 
     methods: {
@@ -52,12 +49,10 @@
         console.log(this.fixedShifts)
       },
       // クリックカレンダーの日付情報をdataに格納しcomputed: filteredShiftでの処理に使用する
-      checkShifts(value) {
-        this.year = value.year
-        this.month = value.month
-        this.date = value.date
-      },
-  }
       checkShifts(checkDate) {
+        const calendarDate = dayjs(checkDate.year + "-" + checkDate.month + "-" + checkDate.date).format("DD/MM/YYYY")
+        this.filteredShifts =  this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
+      }
+    },
 }
 </script>

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -58,5 +58,6 @@
         this.date = value.date
       },
   }
+      checkShifts(checkDate) {
 }
 </script>

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -28,12 +28,9 @@
 
     data() {
       return{
-        shiftData: [],
-        userData: {},
-        selectedShift: {},
-        year: null,
-        month: null,
-        date: null,
+        year: 0,
+        month: 0,
+        date: 0,
         fixedShifts: [],
         filteredShifts: []
       }

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -35,7 +35,6 @@
 <script>
   import dayjs from "dayjs";
   import Calendar from "../../components/FixedShiftsCalendar.vue"
-  import Modal from "../../components/Modal.vue"
   import UserName from "../../components/UserName.vue"
   import UserAge from "../../components/UserAge.vue"
   import UserWorkStatus from "../../components/UserWorkStatus.vue"
@@ -46,7 +45,6 @@
   export default {
     components: {
       Calendar,
-      Modal,
       UserName,
       UserAge,
       UserWorkStatus,
@@ -62,7 +60,6 @@
         year: null,
         month: null,
         date: null,
-        showModal: false
         fixedShifts: []
       }
     },

--- a/app/javascript/views/staff/FixedShifts.vue
+++ b/app/javascript/views/staff/FixedShifts.vue
@@ -41,6 +41,8 @@
   import UserWorkStatus from "../../components/UserWorkStatus.vue"
   import RequestedClockInTime from "../../components/RequestedClockInTime.vue"
   import RequestedClockOutTime from "../../components/RequestedClockOutTime.vue"
+  import axios from "axios";
+
   export default {
     components: {
       Calendar,
@@ -61,35 +63,26 @@
         month: null,
         date: null,
         showModal: false
+        fixedShifts: []
       }
     },
-
     created() {
-      this.$store.dispatch("getAllShiftByStaff")
+      this.fetchFixedShifts();
       this.$store.dispatch("getAllUsers")
     },
-
     computed: {
       // カレンダーで指定した日付のシフト情報とそのシフトのユーザー情報を取得し表示する
       filteredShiftData() {
         const calendarDate = dayjs(this.year + "-" + this.month + "-" + this.date).format("DD/MM/YYYY")
-      const shifts = this.$store.state.fixedShiftsInTableData.filter(function (item) {
-        const shiftDate = dayjs(item.clock_in).format("DD/MM/YYYY")
-        return calendarDate === shiftDate
-      })
-      return shifts.map(shift => {
-        const user = this.$store.state.allUsersData.find(function (user) {
-        return user.id === shift.user_id
-        })
-        return {
-          ...shift,
-          user: user
-        }
-      })
+        return this.fixedShifts.filter(shift => calendarDate === dayjs(shift.clock_in).format("DD/MM/YYYY"))
       },
     },
 
     methods: {
+      async fetchFixedShifts() {
+        const response = await axios.get("/api/v1/staff/fixed_shifts")
+        this.fixedShifts = response.data
+      },
       // クリックカレンダーの日付情報をdataに格納しcomputed: filteredShiftでの処理に使用する
       checkShifts(value) {
         this.year = value.year

--- a/app/javascript/views/staff/RequestedShiftsDetail.vue
+++ b/app/javascript/views/staff/RequestedShiftsDetail.vue
@@ -60,10 +60,10 @@
     data() {
       return {
         shift: {},
-        year: null,
-        month: null,
-        date: null,
-        shiftId: null,
+        year: 0,
+        month: 0,
+        date: 0,
+        shiftId: 0,
         showModal: false
       };
     },

--- a/app/views/api/v1/staff/fixed_shifts/index.jbuilder
+++ b/app/views/api/v1/staff/fixed_shifts/index.jbuilder
@@ -1,0 +1,7 @@
+json.array! @shifts do |shift|
+  json.id shift.id
+  json.clock_in shift.clock_in
+  json.clock_out shift.clock_out
+  json.user_id shift.user_id
+  json.user shift.user
+end

--- a/app/views/api/v1/staff/index.jbuilder
+++ b/app/views/api/v1/staff/index.jbuilder
@@ -1,0 +1,7 @@
+json.array! @shifts do |shift|
+  json.id shift.id
+  json.clock_in shift.clock_in
+  json.clock_out shift.clock_out
+  json.user_id shift.user_id
+  json.user shift.user
+end

--- a/app/views/api/v1/staff/index.jbuilder
+++ b/app/views/api/v1/staff/index.jbuilder
@@ -1,7 +1,0 @@
-json.array! @shifts do |shift|
-  json.id shift.id
-  json.clock_in shift.clock_in
-  json.clock_out shift.clock_out
-  json.user_id shift.user_id
-  json.user shift.user
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         resources :users, only: [:index, :show]
         resources :requested_shifts, only: [:index, :create, :update, :destroy]
         resources :fixed_shifts, only: [:index]
+        get "/current_user_fixed_shifts", to: "fixed_shifts#current_user_fixed_shifts"
       end
     end
   end


### PR DESCRIPTION
関連issue: #74 

1. 目的   
  重複している部分をcomponentに切り分けることでコードの可読性、保守性を向上させる

2. 実装の概要  
  ShiftTable.vueファイルを新規作成し、コードを移行する

3 特に見てほしい箇所
　管理者とユーザーで違うフォーマットのシフト表を描画するよう、ファイル内で条件分岐の
処理を追記しました。適切に書けているかご確認頂きたいです。

5. スケジュール
いつでも大丈夫です。お時間のあるときにご確認頂けると幸いです。

お忙しいところ恐縮ですが、ご確認お願いいたします。
